### PR TITLE
Fix data structure for report object

### DIFF
--- a/ckanext/metrics_dashboard/plugin.py
+++ b/ckanext/metrics_dashboard/plugin.py
@@ -12,25 +12,17 @@ class MetricsDashboard(p.SingletonPlugin, p.toolkit.DefaultDatasetForm):
     change, and will create a new ckanext.archiver celery task to archive the
     resource.
     """
-    p.implements(p.IDomainObjectModification, inherit=True)
     p.implements(IReport)
     p.implements(p.IConfigurer, inherit=True)
-    p.implements(p.ITemplateHelpers)
 
     # IReport
 
     def register_reports(self):
         """Register details of an extension's reports"""
         from ckanext.metrics_dashboard import reports
-        return [reports.metrics_dashboard_report_info,
-                ]
+        return [reports.metrics_dashboard_report_info]
 
     # IConfigurer
 
     def update_config(self, config):
         p.toolkit.add_template_directory(config, 'templates')
-
-    # ITemplateHelpers
-
-    def get_helpers(self):
-        return {}

--- a/ckanext/metrics_dashboard/reports.py
+++ b/ckanext/metrics_dashboard/reports.py
@@ -54,6 +54,10 @@ def _get_harvest_results(organization=None):
         source = p.toolkit.get_action("harvest_source_show")(
             context, {"id": id}
         )
+        if source['state'] == 'deleted':
+            continue
+            # TODO: process deleted datasets so a logged in user can see those as well
+
         last_job = source['status']['last_job']
         source_org = source['organization']
         if not last_job:

--- a/ckanext/metrics_dashboard/reports.py
+++ b/ckanext/metrics_dashboard/reports.py
@@ -54,25 +54,46 @@ def _get_harvest_results(organization=None):
         source = p.toolkit.get_action("harvest_source_show")(
             context, {"id": id}
         )
+        last_job = source['status']['last_job']
+        source_org = source['organization']
+        if not last_job:
+            last_job = {
+                'created': 'N/A',
+                'finished': 'N/A',
+                'status': 'N/A',
+                'stats': {
+                    'added': 'N/A',
+                    'updated': 'N/A',
+                    'not modified': 'N/A',
+                    'errored': 'N/A',
+                    'deleted': 'N/A',
+                },
+                'object_error_summary': 'N/A',
+            }
+        if not source_org:
+            source_org = {
+                'name': 'N/A',
+                'title': 'N/A',
+            }
         row_data = OrderedDict((
             ('name', source['name']),
             ('metadata_created', source['metadata_created']),
             ('source_type', source['source_type']),
             ('state', source['state']),
             ('frequency', source['frequency']),
-            ('organization_name', source['organization']['name']),
-            ('organization_title', source['organization']['title']),
+            ('organization_name', source_org['name']),
+            ('organization_title', source_org['title']),
             ('job_count', source['status']['job_count']),
             ('total_datasets', source['status']['total_datasets']),
-            ('last_job_created', source['status']['last_job']['created']),
-            ('last_job_finished', source['status']['last_job']['finished']),
-            ('last_job_status', source['status']['last_job']['status']),
-            ('last_job_added', source['status']['last_job']['stats']['added']),
-            ('last_job_updated', source['status']['last_job']['stats']['updated']),
-            ('last_job_not_modified', source['status']['last_job']['stats']['not modified']),
-            ('last_job_errored', source['status']['last_job']['stats']['errored']),
-            ('last_job_deleted', source['status']['last_job']['stats']['deleted']),
-            ('object_error_summary', source['status']['last_job']['object_error_summary']),  # not yet implemented
+            ('last_job_created', last_job['created']),
+            ('last_job_finished', last_job['finished']),
+            ('last_job_status', last_job['status']),
+            ('last_job_added', last_job['stats']['added']),
+            ('last_job_updated', last_job['stats']['updated']),
+            ('last_job_not_modified', last_job['stats']['not modified']),
+            ('last_job_errored', last_job['stats']['errored']),
+            ('last_job_deleted', last_job['stats']['deleted']),
+            ('object_error_summary', last_job['object_error_summary']),  # not yet implemented
         ))
 
         table_data.append(row_data)  # needed for csv export

--- a/ckanext/metrics_dashboard/reports.py
+++ b/ckanext/metrics_dashboard/reports.py
@@ -120,10 +120,6 @@ def _get_harvest_results(organization=None):
     }
 
 
-def metrics_dashboard_option_combinations():
-    pass
-
-
 metrics_dashboard_report_info = {
     'name': 'metrics-dashboard',
     'title': 'Metrics Dashboard',
@@ -131,7 +127,7 @@ metrics_dashboard_report_info = {
     'option_defaults': OrderedDict((('organization', None),
                                     ('include_sub_organizations', False),
                                     )),
-    'option_combinations': metrics_dashboard_option_combinations,
+    'option_combinations': None,
     'generate': metrics_dashboard,
     'template': 'report/metrics_dashboard.html',
 }

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
-version = '0.1.2'
+version = '0.1.3'
 
 setup(
     name='ckanext-metrics_dashboard',


### PR DESCRIPTION
fixes:
- creates default table object when last_job & source_org are not present in harvest source object
- cleans up unused plugins
- cleans up method params
- retains option_defaults as that allows the report to function as expected

notes:
- internal route needing login to resolve was solved by invalidating cloudfront cdn cache

relates to:
- https://github.com/GSA/data.gov/issues/4016 